### PR TITLE
Simplify Jenkinsfile with shared pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 servicePipeline(
-    upstreamProjects: ['dockers/master'],
     deployTargets: ['metabase'],
 )
 


### PR DESCRIPTION
This follows the same steps that templates, ocfweb, and ircbot (etc.) have already followed to use the shared service pipeline.