### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/kubernetes/metabase.yml.erb
+++ b/kubernetes/metabase.yml.erb
@@ -37,6 +37,20 @@ spec:
               cpu: 750m
           ports:
             - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 120
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 60
+            timeoutSeconds: 3
+            periodSeconds: 5
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
Readiness probes are probes that determine when a pod is ready to accept traffic. They are currently set to start at 60 seconds because metabase is slow to start up (thanks JVM).

Liveness probes determine whether a pod is able to continue accepting traffic. All values (except the 60 seconds) are pulled from the helm metabase kubernetes deployment. (https://github.com/helm/charts/blob/master/stable/metabase/templates/deployment.yaml)

